### PR TITLE
added typecheck script and updated document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,7 +415,7 @@ When working with health-related features:
 - [ ] TypeScript types are properly defined
 - [ ] Code has been tested on iOS and/or Android
 - [ ] Linter passes (`pnpm lint`)
-- [ ] Type check passes (`npx tsc --noEmit`)
+- [ ] Type check passes (`pnpm typecheck`)
 - [ ] Commit messages follow conventions
 - [ ] Documentation updated (if needed)
 - [ ] Medical disclaimers included (if applicable)
@@ -455,8 +455,8 @@ Describe the tests you ran:
 - [ ] Tested on Android
 - [ ] Tested with medical condition: [specify]
 - [ ] Tested offline fallback
-- [ ] Linter passed
-- [ ] Type checking passed
+- [ ] Linter passed (`pnpm lint`)
+- [ ] Type checking passed (`pnpm typecheck`)
 
 ## Screenshots (if applicable)
 [Add screenshots here]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@apollo/client": "^3.4.10",


### PR DESCRIPTION
Successfully added typecheck script - "typecheck": "tsc --noEmit"
Updated the documentation to include running the typecheck command alongside the linting in the pre-PR checklist.